### PR TITLE
refactor(project) Using custom Pair utility class

### DIFF
--- a/src/main/java/org/lambdamatic/elasticsearch/utils/Pair.java
+++ b/src/main/java/org/lambdamatic/elasticsearch/utils/Pair.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat. All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which accompanies this
+ * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package org.lambdamatic.elasticsearch.utils;
+
+/**
+ * Utility class to handle a pair of objects in a single reference, for example, as the result of a
+ * method call.
+ * @param <L> the type of the left-side value
+ * @param <R> the type of the right-side value
+ */
+public class Pair<L,R> {
+
+  /** the left-side value. */
+  private final L left;
+  
+  /** the right-side value. */
+  private final R right;
+
+  /**
+   * Constructor.
+   * @param left the left-side value
+   * @param right the right-side value
+   */
+  public Pair(L left, R right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  /**
+   * @return the left-side value.
+   */
+  public L getLeft() {
+    return left;
+  }
+
+  /**
+   * @return the right-side value.
+   */
+  public R getRight() {
+    return right;
+  }
+  
+  
+}

--- a/src/main/java/org/lambdamatic/internal/elasticsearch/MappingUtils.java
+++ b/src/main/java/org/lambdamatic/internal/elasticsearch/MappingUtils.java
@@ -19,9 +19,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.lambdamatic.elasticsearch.annotations.DocumentField;
 import org.lambdamatic.elasticsearch.annotations.DocumentId;
+import org.lambdamatic.elasticsearch.utils.Pair;
 
 /**
  * Utility class for domain class mapping in an Elasticsearch index.
@@ -56,20 +56,20 @@ public interface MappingUtils {
    *         these criteria, a {@link MappingException} is thrown.
    */
   public static String getIdFieldName(Class<?> domainType) {
-    final List<ImmutablePair<Field, DocumentId>> candidateFields =
+    final List<Pair<Field, DocumentId>> candidateFields =
         Stream.of(domainType.getDeclaredFields())
-            .map(field -> ImmutablePair.of(field, field.getAnnotation(DocumentId.class)))
-            .filter(pair -> pair.right != null).collect(Collectors.toList());
+            .map(field -> new Pair<>(field, field.getAnnotation(DocumentId.class)))
+            .filter(pair -> pair.getRight() != null).collect(Collectors.toList());
     if (candidateFields.isEmpty()) {
       return null;
     } else if (candidateFields.size() > 1) {
-      final String fieldNames = candidateFields.stream().map(pair -> pair.left.getName())
+      final String fieldNames = candidateFields.stream().map(pair -> pair.getLeft().getName())
           .collect(Collectors.joining(", "));
       throw new MappingException(
           "More than one field is annotated with '@'" + DocumentId.class.getName() + ": {}",
           fieldNames);
     }
-    final Field domainField = candidateFields.get(0).left;
+    final Field domainField = candidateFields.get(0).getLeft();
     return domainField.getName();
   }
 

--- a/src/test/java/org/lambdamatic/internal/elasticsearch/MappingUtilsTest.java
+++ b/src/test/java/org/lambdamatic/internal/elasticsearch/MappingUtilsTest.java
@@ -12,7 +12,6 @@
 package org.lambdamatic.internal.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
 
 import java.util.Map;
 


### PR DESCRIPTION
Since the ImmutablePair is not in the classpath anymore
(was par to commons-lang3 dependency brought by
lambdamatic-analyzer)

Signed-off-by: Xavier Coulon xcoulon@redhat.com
