### PR TITLE
feat(API) Get and Async Get

### DIFF
--- a/src/main/java/org/lambdamatic/elasticsearch/DocumentManagement.java
+++ b/src/main/java/org/lambdamatic/elasticsearch/DocumentManagement.java
@@ -11,11 +11,7 @@
 
 package org.lambdamatic.elasticsearch;
 
-import org.elasticsearch.action.delete.DeleteResponse;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.client.Client;
-import org.reactivestreams.Publisher;
+import java.util.function.Consumer;
 
 /**
  * Interface for all operations related to document management.
@@ -33,20 +29,27 @@ public interface DocumentManagement<D> {
    *         underlying {@link Client}.
    * TODO: return a simpler type to handle the response. 
    */
-  public Publisher<IndexResponse> index(D document);
+  //public Publisher<IndexResponse> index(D document);
 
   /**
-   * The gets the document identified by the given {@code id} from the index.
+   * The gets the document identified by the given {@code documentId} from the index.
    * 
    * @param documentId the id of the document to get
-   * @return A <a href=
-   *         "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md">
-   *         Reactive Streams</a> {@link Publisher} for the {@link GetResponse} returned by the
-   *         underlying {@link Client}.
-   * TODO: return a simpler type to handle the response. 
+   * @return the instance of document whose id matches the given {@code documentId},
+   *         <code>null</code> if no document was found. 
    */
-  public Publisher<GetResponse> get(String documentId);
+  public D get(String documentId);
 
+  /**
+   * The gets the document identified by the given {@code documentId} from the index.
+   * 
+   * @param documentId the id of the document to get
+   * @param onSuccess the handler to call when the operation succeeds
+   * @param onError the handler to call if the operation failed 
+   * 
+   */
+  public void asyncGet(String documentId, Consumer<D> onSuccess, Consumer<Throwable> onError);
+  
   /**
    * The delete API allows one to delete a typed JSON document from a specific index based on its
    * id.
@@ -59,7 +62,7 @@ public interface DocumentManagement<D> {
    *         underlying {@link Client}.
    * TODO: return a simpler type to handle the response. 
    */
-  public Publisher<DeleteResponse> delete(Object documentId);
+  //public Publisher<DeleteResponse> delete(Object documentId);
 
   
 }

--- a/src/main/java/org/lambdamatic/elasticsearch/DocumentSearch.java
+++ b/src/main/java/org/lambdamatic/elasticsearch/DocumentSearch.java
@@ -11,6 +11,8 @@
 
 package org.lambdamatic.elasticsearch;
 
+import org.lambdamatic.elasticsearch.querydsl.FilterContext;
+import org.lambdamatic.elasticsearch.querydsl.MustMatchContext;
 import org.lambdamatic.elasticsearch.querydsl.ShouldMatchContext;
 import org.lambdamatic.internal.elasticsearch.QueryMetadata;
 
@@ -20,7 +22,7 @@ import org.lambdamatic.internal.elasticsearch.QueryMetadata;
  * @param <D> the type of documents stored in the associated index.
  * @param <Q> the {@link QueryMetadata} type associated with the type of documents.
  */
-public interface DocumentSearch<D, Q> extends ShouldMatchContext<D, Q> {
+public interface DocumentSearch<D, Q> extends ShouldMatchContext<D, Q>, MustMatchContext<D, Q>, FilterContext<D, Q> {
 
   
 }

--- a/src/main/java/org/lambdamatic/elasticsearch/ElasticsearchDomainTypeManager.java
+++ b/src/main/java/org/lambdamatic/elasticsearch/ElasticsearchDomainTypeManager.java
@@ -18,7 +18,7 @@ import org.lambdamatic.internal.elasticsearch.QueryMetadata;
  */
 public interface ElasticsearchDomainTypeManager<D, Q extends QueryMetadata<D>>
     extends 
-    //DocumentManagement<D>, 
+    DocumentManagement<D>, 
     DocumentSearch<D, Q> {
 
   // nothing more here.

--- a/src/main/java/org/lambdamatic/elasticsearch/querydsl/MustMatchContext.java
+++ b/src/main/java/org/lambdamatic/elasticsearch/querydsl/MustMatchContext.java
@@ -27,5 +27,5 @@ public interface MustMatchContext<D, Q> extends FilterContext<D, Q> {
    *         "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md">
    *         Reactive Streams</a> {@link Publisher} for the domain-type specific search result.
    */
-  public Collectable<D, Q> mustMatch(QueryExpression<Q> expression);
+  public FilterContext<D, Q> mustMatch(QueryExpression<Q> expression);
 }

--- a/src/main/java/org/lambdamatic/elasticsearch/querydsl/ShouldMatchContext.java
+++ b/src/main/java/org/lambdamatic/elasticsearch/querydsl/ShouldMatchContext.java
@@ -27,6 +27,6 @@ public interface ShouldMatchContext<D, Q> extends MustMatchContext<D, Q> {
    *         "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md">
    *         Reactive Streams</a> {@link Publisher} for the domain-type specific search result.
    */
-  public Collectable<D, Q> shouldMatch(QueryExpression<Q> expression);
+  public MustMatchContext<D, Q> shouldMatch(QueryExpression<Q> expression);
   
 }

--- a/src/main/java/org/lambdamatic/internal/elasticsearch/reactivestreams/GetPublisher.java
+++ b/src/main/java/org/lambdamatic/internal/elasticsearch/reactivestreams/GetPublisher.java
@@ -18,7 +18,6 @@ import org.reactivestreams.Subscriber;
  * A <a href= "https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/README.md">
  * Reactive Streams</a> {@link Publisher} a <code>Get</code> operation.
  */
-@Deprecated
 public class GetPublisher implements Publisher<GetResponse> {
 
   /**


### PR DESCRIPTION
Restoring the `get(String)` method that works
synchronously now, along with an asynchronous
`asyncGet(String, Consumer<D>, Consumer<D>)`

Signed-off-by: Xavier Coulon xcoulon@redhat.com
